### PR TITLE
Add generatorName in VariantTaskConfig to obey schema

### DIFF
--- a/bbp_workflow/generation/entity.py
+++ b/bbp_workflow/generation/entity.py
@@ -38,6 +38,7 @@ class GeneratorTaskConfig(BbpWorkflowConfig):
 @attributes(
     {
         "distribution": AttrOf(DataDownload),
+        "generatorName": AttrOf(str, default=None),
     }
 )
 class VariantTaskConfig(BbpWorkflowConfig):

--- a/bbp_workflow/generation/generator_base.py
+++ b/bbp_workflow/generation/generator_base.py
@@ -188,7 +188,9 @@ class GeneratorTask(KgTask):
         # create or find config that parametrizes the variant definition
         config = create_or_find(
             entity_cls=VariantTaskConfig,
-            properties={},
+            properties={
+                "generatorName": self.generator_name,
+            },
             serialized_content=json.dumps({"inputs": input_values}),
             filename="variant_task_configuration.json",
             content_type="application/json",


### PR DESCRIPTION
VariantTaskConfig's schema derives from ModelSubConfig which requires a generatorName property:

https://bbpgitlab.epfl.ch/dke/apps/brain-modeling-ontology/-/blob/main/shapes/commons/modelsubconfig.json?ref_type=heads#L18
